### PR TITLE
Add support for minSDKVersion=19

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,10 +10,10 @@ android {
 
     defaultConfig {
         applicationId "shem.com.materiallogin.ex"
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 23
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1"
     }
     buildTypes {
         release {

--- a/material-login/build.gradle
+++ b/material-login/build.gradle
@@ -34,7 +34,7 @@ android {
     buildToolsVersion buildTools
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
This patch lowers the minimum supported SDK version to API-19.  By implementing this fix, this library can now be used by developers targeting pre-lollipop devices.